### PR TITLE
prevents iresize filter not working with spaces in file/folder names

### DIFF
--- a/classes/MediaExtensions.php
+++ b/classes/MediaExtensions.php
@@ -55,7 +55,7 @@ class MediaExtensions extends \Backend\Classes\Controller
     public static function iresize($image, $width=null, $height=null, $filters=null, $extension=null, $quality=null)
     {
     	// Check if the file exists
-        $path = public_path(parse_url($image, PHP_URL_PATH));
+        $path = urldecode(public_path(parse_url($image, PHP_URL_PATH)));
         if (!File::exists($path)) {
             return $image;
         }


### PR DESCRIPTION
File:exists() does not seem to support urlencoded paths. So the path had to be urldecoded first to make it work.